### PR TITLE
Use NodeJS 22 for the CI and tests

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,7 +31,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Install Dependencies
         run: yarn

--- a/test/app/Dockerfile
+++ b/test/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/node:20-alpine
+FROM docker.io/library/node:22-alpine
 
 WORKDIR /app
 


### PR DESCRIPTION
Let's switch to the future Node LTS, in order to check that everything would be working.