### PR TITLE
Create dependency groups for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,18 @@ updates:
     directory: "/test/app"
     schedule:
       interval: "weekly"
+    groups:
+      eslint:
+        patterns:
+          - "eslint"
+          - "@eslint/*"
+          - "@types/eslint__*"
+          - "typescript-eslint"
+      typescript:
+        patterns:
+          - "typescript"
+          - "ts-node"
+      fastify:
+        patterns:
+          - "fastify"
+          - "@fastify/*"


### PR DESCRIPTION
Dependabot is very useful for having up-to-date dependencies and making sure that everything is working as expected with new versions, but it creates many PRs.

This PR is regrouping some modules together, in order to help to review the changes suggested by Dependabot.