### PR TITLE
Upgrade to Go 1.23

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the prometheus_varnish_exporter binary
-FROM docker.io/library/golang:1.22 as prometheus_varnish_exporter
+FROM docker.io/library/golang:1.23 as prometheus_varnish_exporter
 WORKDIR /app
 
 # Releases: https://github.com/jonnenauha/prometheus_varnish_exporter/releases

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the prometheus_varnish_exporter binary
-FROM docker.io/library/golang:1.23 as prometheus_varnish_exporter
+FROM docker.io/library/golang:1.23 AS prometheus_varnish_exporter
 WORKDIR /app
 
 # Releases: https://github.com/jonnenauha/prometheus_varnish_exporter/releases

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ WORKDIR /app
 # Releases: https://github.com/jonnenauha/prometheus_varnish_exporter/releases
 ARG PROMETHEUS_VARNISH_EXPORTER_VERSION=1.6.1
 
-RUN git clone https://github.com/jonnenauha/prometheus_varnish_exporter.git . \
+RUN git config --global advice.detachedHead false \
+  && git clone https://github.com/jonnenauha/prometheus_varnish_exporter.git . \
   && git checkout "${PROMETHEUS_VARNISH_EXPORTER_VERSION}" \
   && go mod download \
   && go build -o prometheus_varnish_exporter


### PR DESCRIPTION
Upgrade Go from 1.22 to 1.23 to build the Prometheus exporter.
This PR also removes the `detachedHead` Git advice and use consistent casing in the Dockerfile.